### PR TITLE
add support gtag 'set'

### DIFF
--- a/lib/src/gtag.service.ts
+++ b/lib/src/gtag.service.ts
@@ -55,6 +55,14 @@ export class Gtag {
     }
   }
 
+  set(params: any) {
+    try {
+      gtag('set', (params = {}));
+    } catch (err) {
+      console.error('Google Analytics set error', err);
+    }
+  }
+
   private debug(...msg) {
     if (this.mergedConfig.debug) {
       console.log('angular-gtag:', ...msg);


### PR DESCRIPTION
In order to support set UserId, we can add `gtag('set', {'user_id': this.userId});` to enable a User Id view.