### PR TITLE
Option to enable/disable all analytics

### DIFF
--- a/lib/src/gtag.service.ts
+++ b/lib/src/gtag.service.ts
@@ -8,7 +8,7 @@ declare var gtag: any;
 export class Gtag {
   private mergedConfig: GtagConfig;
   constructor(@Inject('config') gaConfig: GtagConfig, private router: Router) {
-    this.mergedConfig = { trackPageviews: true, ...gaConfig };
+    this.mergedConfig = { trackPageviews: true, enabled: true, ...gaConfig };
     if (this.mergedConfig.trackPageviews) {
       router.events
         .pipe(
@@ -22,28 +22,32 @@ export class Gtag {
   }
 
   event(action: string, params: GtagEvent = {}) {
-    // try/catch to avoid cross-platform issues
-    try {
-      gtag('event', action, params);
-      this.debug('event', this.mergedConfig.trackingId, action, params);
-    } catch (err) {
-      console.error('Google Analytics event error', err);
+    if (this.mergedConfig.enabled) {
+      // try/catch to avoid cross-platform issues
+      try {
+        gtag('event', action, params);
+        this.debug('event', this.mergedConfig.trackingId, action, params);
+      } catch (err) {
+        console.error('Google Analytics event error', err);
+      }
     }
   }
 
   pageview(params?: GtagPageview) {
-    try {
-      const defaults = {
-        page_path: this.router.url,
-        page_title: 'Angular App',
-        page_location: window.location.href
-      };
+    if (this.mergedConfig.enabled) {
+      try {
+        const defaults = {
+          page_path: this.router.url,
+          page_title: 'Angular App',
+          page_location: window.location.href
+        };
 
-      params = { ...defaults, ...params };
-      gtag('config', this.mergedConfig.trackingId, params);
-      this.debug('pageview', this.mergedConfig.trackingId, params);
-    } catch (err) {
-      console.error('Google Analytics pageview error', err);
+        params = { ...defaults, ...params };
+        gtag('config', this.mergedConfig.trackingId, params);
+        this.debug('pageview', this.mergedConfig.trackingId, params);
+      } catch (err) {
+        console.error('Google Analytics pageview error', err);
+      }
     }
   }
 
@@ -53,6 +57,10 @@ export class Gtag {
     } catch (err) {
       console.error('Google Analytics config error', err);
     }
+  }
+
+  enable(enabled: boolean = true) {
+    this.mergedConfig.enabled = enabled;
   }
 
   private debug(...msg) {

--- a/lib/src/interfaces.ts
+++ b/lib/src/interfaces.ts
@@ -16,4 +16,5 @@ export interface GtagConfig {
   trackingId: string;
   trackPageviews?: boolean;
   debug?: boolean;
+  enabled: boolean;
 }


### PR DESCRIPTION
To comply with GDPR and other data protection laws, analytics may only be recorded once the user has accepted them. Google Analytics also sets cookies which must be explicitly allowed. This PR allows a dev to disable analytics by default until the user accepts their usage.